### PR TITLE
feat: add more tests user endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ whoami = "1.4.1"
 [dev-dependencies]
 tokio = { version = "1.36.0", features = ["macros"] }
 dotenv = "0.15.0"
+uuid= { version = "1.7.0", features = ["v4", "fast-rng", "macro-diagnostics"]}

--- a/src/err.rs
+++ b/src/err.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{collections::HashMap, fmt};
 
 pub type Result<T> = std::result::Result<T, JellyfinError>;
 
@@ -9,30 +9,28 @@ pub enum JellyfinError {
     AuthNotFound,
     HttpRequestError {
         status: u16,
-        type_: Option<String>, // Using type_ because `type` is a reserved keyword in Rust
+        type_: Option<String>,
         title: Option<String>,
         detail: Option<String>,
         instance: Option<String>,
-        property1: Option<String>,
-        property2: Option<String>,
-        message: String, // To hold a simple error message or non-JSON response body
+        errors: HashMap<String, Vec<String>>, // Dynamic error fields
+        message: String,
     },
 }
 
 impl fmt::Display for JellyfinError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::NetworkError(v) => write!(f, "{}", v),
-            Self::UrlParseError(v) => write!(f, "{}", v),
-            Self::AuthNotFound => write!(f, "Unauthorized."),
+            Self::NetworkError(e) => write!(f, "{}", e),
+            Self::UrlParseError(e) => write!(f, "{}", e),
+            Self::AuthNotFound => write!(f, "Unauthorized"),
             Self::HttpRequestError {
                 status,
                 type_,
                 title,
                 detail,
                 instance,
-                property1,
-                property2,
+                errors,
                 message,
             } => {
                 write!(f, "HTTP Request Error (Status {}): {}", status, message)?;
@@ -48,11 +46,8 @@ impl fmt::Display for JellyfinError {
                 if let Some(i) = instance {
                     write!(f, ", Instance: {}", i)?;
                 }
-                if let Some(p1) = property1 {
-                    write!(f, ", Property1: {}", p1)?;
-                }
-                if let Some(p2) = property2 {
-                    write!(f, ", Property2: {}", p2)?;
+                for (key, messages) in errors {
+                    write!(f, ", {}: {:?}", key, messages)?;
                 }
                 Ok(())
             }

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -1,3 +1,5 @@
+use uuid::Uuid;
+
 use crate::{
     err::JellyfinError,
     tests::{get_config, init_test_client},
@@ -5,15 +7,21 @@ use crate::{
     JellyfinClient,
 };
 
+pub fn generate_uuid() -> String {
+    Uuid::new_v4().to_string()
+}
+
 #[tokio::test]
 async fn create_user_success() -> Result<(), Box<dyn std::error::Error>> {
     let client = init_test_client().await?;
 
+    let random_user_name = generate_uuid();
+
     let created_user = client
-        .create_user("tempuser".to_string(), "tempuser".to_string())
+        .create_user(random_user_name.clone(), random_user_name.clone())
         .await?;
 
-    assert_eq!(created_user.name, "tempuser".to_string());
+    assert_eq!(created_user.name, random_user_name);
 
     // Clean up
     client.delete_user(created_user.id).await?;
@@ -25,14 +33,16 @@ async fn create_user_success() -> Result<(), Box<dyn std::error::Error>> {
 async fn create_user_duplicate_username() -> Result<(), Box<dyn std::error::Error>> {
     let client = init_test_client().await?;
 
+    let random_user_name = generate_uuid();
+
     let created_user = client
-        .create_user("temp".to_string(), "temp".to_string())
+        .create_user(random_user_name.clone(), random_user_name.clone())
         .await?;
 
-    assert_eq!(created_user.name, "temp".to_string());
+    assert_eq!(created_user.name, random_user_name.clone());
 
     let result_duplicate_user = client
-        .create_user("temp".to_string(), "temp".to_string())
+        .create_user(random_user_name.clone(), random_user_name.clone())
         .await;
 
     assert!(result_duplicate_user.is_err());
@@ -47,11 +57,13 @@ async fn create_user_duplicate_username() -> Result<(), Box<dyn std::error::Erro
 async fn update_user_success() -> Result<(), Box<dyn std::error::Error>> {
     let client = init_test_client().await?;
 
+    let random_user_name = generate_uuid();
+
     let mut created_user = client
-        .create_user("updateuser".to_string(), "updateuser".to_string())
+        .create_user(random_user_name.clone(), random_user_name.clone())
         .await?;
 
-    assert_eq!(created_user.name, "updateuser".to_string());
+    assert_eq!(created_user.name, random_user_name);
     assert_eq!(
         created_user.configuration.subtitle_mode,
         SubtitleMode::Default
@@ -85,17 +97,18 @@ async fn update_user_success() -> Result<(), Box<dyn std::error::Error>> {
 async fn delete_user_success() -> Result<(), Box<dyn std::error::Error>> {
     let client = init_test_client().await?;
 
+    let random_user_name = generate_uuid();
+
     let created_user = client
-        .create_user("deleteuser".to_string(), "deleteuser".to_string())
+        .create_user(random_user_name.clone(), random_user_name.clone())
         .await?;
 
-    assert_eq!(created_user.name, "deleteuser".to_string());
+    assert_eq!(created_user.name, random_user_name.clone());
 
     // Clean up
     client.delete_user(&created_user.id).await?;
 
     // Confirm user is deleted
-
     let not_found_user = client.get_user_by_id(created_user.id).await;
 
     assert!(
@@ -174,6 +187,65 @@ async fn get_user_by_id_non_existing_id() -> Result<(), Box<dyn std::error::Erro
 }
 
 #[tokio::test]
+async fn auth_user_std_success() -> Result<(), Box<dyn std::error::Error>> {
+    let (url, _, password) = get_config();
+    let client = init_test_client().await?;
+
+    let user_id = client.auth.clone().unwrap().user.id;
+
+    let mut client2 = JellyfinClient::new_auth_std(url, user_id.clone(), password.clone()).await?;
+
+    client2.auth_user_std(user_id, password).await?;
+
+    // Assert that the client's `auth` field is now set
+    assert!(
+        client2.auth.is_some(),
+        "Client auth should be set after successful standard authentication using id and password"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn auth_user_std_user_not_found() -> Result<(), Box<dyn std::error::Error>> {
+    let (_, _, password) = get_config();
+
+    let mut client = init_test_client().await?;
+
+    let not_found_user_id = "16e7d2b322a84b3cae8e0b06a04c9f79".to_string();
+
+    let result = client
+        .auth_user_std(not_found_user_id.clone(), password)
+        .await;
+
+    assert_ne!(
+        client.auth.unwrap().user.id,
+        not_found_user_id,
+        "Client auth user id should not match"
+    );
+
+    match result {
+        Ok(_) => panic!("Expected an error for non-existing user ID, but got Ok."),
+
+        Err(e) => match e {
+            JellyfinError::HttpRequestError {
+                status, message, ..
+            } => {
+                assert_eq!(status, 404, "Expected HTTP 404 error for user not found.");
+                assert_eq!(
+                    message,
+                    "\"User not found\"".to_string(),
+                    "Expected message `User not found`"
+                )
+            }
+            _ => panic!("Expected HttpRequestError, but got a different error."),
+        },
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn auth_user_name_success() -> Result<(), Box<dyn std::error::Error>> {
     let (server_url, username, password) = get_config();
 
@@ -206,6 +278,97 @@ async fn auth_user_name() -> Result<(), Box<dyn std::error::Error>> {
         result.is_err(),
         "Authentication should fail with incorrect credentials"
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn update_user_config_success() -> Result<(), Box<dyn std::error::Error>> {
+    let client = init_test_client().await?;
+
+    let random_user_name = generate_uuid();
+
+    let mut created_user = client
+        .create_user(random_user_name.clone(), random_user_name.clone())
+        .await?;
+
+    assert_eq!(created_user.name, random_user_name.clone());
+    assert_eq!(
+        created_user.configuration.subtitle_mode,
+        SubtitleMode::Default
+    );
+
+    created_user.configuration.subtitle_mode = SubtitleMode::Smart;
+    created_user.configuration.display_missing_episodes = true;
+
+    let update_user = client
+        .update_user_conf(&created_user.id, created_user.configuration.clone())
+        .await;
+
+    assert!(update_user.is_ok(), "Updating user config be successful");
+
+    // Get the updated user and assert
+    let updated_user = client.get_user_by_id(created_user.id.clone()).await?;
+
+    assert_eq!(
+        updated_user.configuration.subtitle_mode,
+        SubtitleMode::Smart,
+        "Subtitle Mode should be smart after updating user config"
+    );
+
+    assert!(
+        updated_user.configuration.display_missing_episodes,
+        "Display missing episode should be true after config is updated"
+    );
+
+    // Clean up
+    client.delete_user(created_user.id).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn update_user_password_success() -> Result<(), Box<dyn std::error::Error>> {
+    let mut client = init_test_client().await?;
+
+    let random_user_name = generate_uuid();
+
+    let created_user = client
+        .create_user(random_user_name.clone(), random_user_name.clone())
+        .await?;
+
+    assert_eq!(created_user.name, random_user_name.clone());
+
+    let update_user = client
+        .update_user_password(created_user.id.clone(), "newpassword".to_string())
+        .await;
+
+    assert!(
+        update_user.is_ok(),
+        "Updating user password should be successful"
+    );
+
+    let (url, _, _) = get_config();
+
+    let mut client2 =
+        JellyfinClient::new_auth_std(url, created_user.id.clone(), "newpassword".to_string())
+            .await?;
+
+    // Try to auth user with the new password
+    let auth_user = client2
+        .auth_user_std(created_user.id.clone(), "newpassword".to_string())
+        .await;
+
+    assert!(
+        auth_user.is_ok(),
+        "Authenticating after changing password should be successful but faile"
+    );
+
+    // Have to init client again here that way that way auth header is set to admin again.
+    client = init_test_client().await?;
+
+    // Clean Up
+    client.delete_user(created_user.id).await?;
 
     Ok(())
 }

--- a/src/user.rs
+++ b/src/user.rs
@@ -360,13 +360,16 @@ impl JellyfinClient {
             .join(&format!("/Users/{}/Authenticate", id.clone().into()))
             .expect("Failed to join URL");
 
+        // Prepare the query parameters
+        let query_params = AuthUserStdQuery {
+            pw: password.clone().into(),
+            password: format!("{:x}", hasher.finalize()),
+        };
+
         let response = self
         .client
         .post(endpoint_url)
-        .query(&AuthUserStdQuery {
-            pw: password.into(),
-            password: format!("{:x}", hasher.finalize()),
-        })
+        .query(&query_params)
         .header("X-Emby-Authorization", format!("MediaBrowser Client=\"jellyfin-rs\", Device=\"{}\", DeviceId=\"{:x}\", Version=1, Token=\"\"", device_name, md5::compute(device_name.clone())))
         .send()
         .await;


### PR DESCRIPTION
Todo add endpoint test for:

- [ ]  Updates a user's easy password.
- [x]  Updates a user policy.
- [ ]  Authenticates a user with quick connect.
- [ ]  Initiates the forgot password process for a local user.
- [ ]  Redeems a forgot password pin.
- [x]  Gets the user based on auth token.
- [ ]  Gets a list of publicly visible users for display on a login screen.